### PR TITLE
upgrade to shut 0.18.1 in CI and rerender setup files

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,6 +3,7 @@ name: Python application
 on:
   push:
     branches: [ develop ]
+    tags: [ '*' ]
   pull_request:
     branches: [ develop ]
 
@@ -12,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.x']
+        python-version: [ '3.7', '3.8', '3.9', '3.x' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +25,7 @@ jobs:
       run: |
         python -m pip install -q --upgrade pip pytest mypy
         python -m venv .shutenv
-        .shutenv/bin/pip install shut==0.14.1
+        .shutenv/bin/pip install shut==0.18.1
         .shutenv/bin/shut mono install
     - name: Run tests
       run: |

--- a/databind.core/setup.py
+++ b/databind.core/setup.py
@@ -7,12 +7,11 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 def _tempcopy(src, dst):
   import atexit, shutil
   if not os.path.isfile(dst):
     if not os.path.isfile(src):
+      command = sys.argv[1] if len(sys.argv) >= 2 else None
       msg = '"{}" does not exist, and cannot copy it from "{}" either'.format(dst, src)
       # NOTE: In dist/build commands that are not invoked by Pip, we enforce that the license file
       #       must be present. See https://github.com/NiklasRosenstein/shut/issues/22

--- a/databind.json/setup.py
+++ b/databind.json/setup.py
@@ -7,12 +7,11 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 def _tempcopy(src, dst):
   import atexit, shutil
   if not os.path.isfile(dst):
     if not os.path.isfile(src):
+      command = sys.argv[1] if len(sys.argv) >= 2 else None
       msg = '"{}" does not exist, and cannot copy it from "{}" either'.format(dst, src)
       # NOTE: In dist/build commands that are not invoked by Pip, we enforce that the license file
       #       must be present. See https://github.com/NiklasRosenstein/shut/issues/22

--- a/databind/setup.py
+++ b/databind/setup.py
@@ -7,12 +7,11 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 def _tempcopy(src, dst):
   import atexit, shutil
   if not os.path.isfile(dst):
     if not os.path.isfile(src):
+      command = sys.argv[1] if len(sys.argv) >= 2 else None
       msg = '"{}" does not exist, and cannot copy it from "{}" either'.format(dst, src)
       # NOTE: In dist/build commands that are not invoked by Pip, we enforce that the license file
       #       must be present. See https://github.com/NiklasRosenstein/shut/issues/22


### PR DESCRIPTION
This should fix that no tests were running in CI.