### PR TITLE
Fix enumeration value aliases on Python 3.9+

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -1,0 +1,6 @@
+changes:
+- type: fix
+  component: general
+  description: fix interpreting `alias()` annotations on enumeration values in Python3.9+
+    by including extras when looking up field annotations in `DefaultAnnotationsProvider`
+  fixes: []

--- a/databind.core/src/databind/core/annotations/base.py
+++ b/databind.core/src/databind/core/annotations/base.py
@@ -7,7 +7,7 @@ import typing as t
 import typing_extensions as te
 import weakref
 
-from databind.core.types.utils import unpack_type_hint
+from databind.core.types.utils import get_type_hints, unpack_type_hint
 
 T = t.TypeVar('T')
 U = t.TypeVar('U')
@@ -211,7 +211,7 @@ class DefaultAnnotationsProvider(AnnotationsProvider):
 
     # Support te.Annotated on enum values.
     if issubclass(type, enum.Enum):
-      ann = t.get_type_hints(type).get(field_name)
+      ann = get_type_hints(type).get(field_name)
       generic, args = unpack_type_hint(ann)
       if generic == te.Annotated:
         return get_annotation(args[1:], annotation_cls, None)

--- a/databind.core/src/databind/core/types/schema.py
+++ b/databind.core/src/databind/core/types/schema.py
@@ -18,7 +18,7 @@ from nr.pylang.utils import NotSet
 
 import databind.core.annotations as A
 from databind.core.dataclasses import ANNOTATIONS_METADATA_KEY
-from databind.core.types.utils import type_repr
+from databind.core.types.utils import get_type_hints, type_repr
 from .adapter import TypeHintAdapter, TypeHintAdapterError
 from .types import BaseType, ConcreteType, MapType
 
@@ -262,19 +262,12 @@ class ObjectType(BaseType):
     return func(self)
 
 
-def _get_type_hints(type_: t.Any) -> t.Any:
-  if sys.version_info >= (3, 9):
-    return t.get_type_hints(type_, include_extras=True)
-  else:
-    return t.get_type_hints(type_)
-
-
 def dataclass_to_schema(dataclass_type: t.Type, type_hint_adapter: TypeHintAdapter) -> Schema:
   preconditions.check_instance_of(dataclass_type, type)
   preconditions.check_argument(is_dataclass(dataclass_type), 'expected @dataclass type')
 
   fields: t.Dict[str, Field] = {}
-  annotations = _get_type_hints(dataclass_type)
+  annotations = get_type_hints(dataclass_type)
 
   for field in _get_fields(dataclass_type):
     if not field.init:

--- a/databind.core/src/databind/core/types/utils.py
+++ b/databind.core/src/databind/core/types/utils.py
@@ -120,3 +120,15 @@ def populate_type_parameters(
     else:
       new_args.append(type_arg)
   return generic_type[tuple(new_args)]
+
+
+def get_type_hints(type_: t.Any) -> t.Dict[str, t.Any]:
+  """
+  Like #typing.get_type_hints(), but always includes extras. This is important when we want to inspect
+  #typing_extensions.Annotated hints (without extras the annotations are removed).
+  """
+
+  if sys.version_info >= (3, 9):
+    return t.get_type_hints(type_, include_extras=True)
+  else:
+    return t.get_type_hints(type_)


### PR DESCRIPTION

In Python 3.9, the `alias()` annotation was ignored:

```py
class MyEnum(enum.Enum):
  VALUE: te.Annotated[int, alias('Value')] = 0
```

That's because `typing.get_type_hint()` since 3.9 removes `typing.Annotated` from the returned type hints by default. 