### PR TITLE
Handle forward refs in base types and improve logic that determines the item or key/value type in the `CollectionConverter` and `MappingConverter` respectively

### DIFF
--- a/databind.core/.changelog/_unreleased.toml
+++ b/databind.core/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "43fe920b-b6b9-4701-9403-bff9aba2e744"
 type = "improvement"
 description = "Work around highly nested error tracebacks in `Module.convert()` by expanding all converters returned by `Module.get_converter()`. Note that this means `Module.convert()` is no longer called if the module is a child of another module."
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "e2e3fbdf-b19c-443d-bc79-8560dba4b1b5"
+type = "improvement"
+description = "Add `DelegateToClassmethodConverter(serialized_type)` parameter."
+author = "@NiklasRosenstein"

--- a/databind.core/.changelog/_unreleased.toml
+++ b/databind.core/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "b44947f0-8e70-4a29-b584-a20eeff51bba"
+type = "fix"
+description = "Fixed serde of types that have a parameterized generic base class. (First reported in NiklasRosenstein/pydoc-markdown#292)"
+author = "rosensteinniklas@gmail.com"

--- a/databind.core/.changelog/_unreleased.toml
+++ b/databind.core/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "b44947f0-8e70-4a29-b584-a20eeff51bba"
 type = "fix"
 description = "Fixed serde of types that have a parameterized generic base class. (First reported in NiklasRosenstein/pydoc-markdown#292)"
 author = "rosensteinniklas@gmail.com"
+
+[[entries]]
+id = "43fe920b-b6b9-4701-9403-bff9aba2e744"
+type = "improvement"
+description = "Work around highly nested error tracebacks in `Module.convert()` by expanding all converters returned by `Module.get_converter()`. Note that this means `Module.convert()` is no longer called if the module is a child of another module."
+author = "@NiklasRosenstein"

--- a/databind.core/.changelog/_unreleased.toml
+++ b/databind.core/.changelog/_unreleased.toml
@@ -10,9 +10,11 @@ id = "43fe920b-b6b9-4701-9403-bff9aba2e744"
 type = "improvement"
 description = "Work around highly nested error tracebacks in `Module.convert()` by expanding all converters returned by `Module.get_converter()`. Note that this means `Module.convert()` is no longer called if the module is a child of another module."
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"
 
 [[entries]]
 id = "e2e3fbdf-b19c-443d-bc79-8560dba4b1b5"
 type = "improvement"
 description = "Add `DelegateToClassmethodConverter(serialized_type)` parameter."
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"

--- a/databind.core/pyproject.toml
+++ b/databind.core/pyproject.toml
@@ -18,7 +18,7 @@ python = "^3.6.3"
 Deprecated = "^1.2.12"
 nr-date = "^2.0.0"
 nr-stream = "^1.0.0"
-typeapi = "^1.4.2"
+typeapi = "^2.0.1"
 typing-extensions = ">=3.10.0"
 
 [tool.poetry.dev-dependencies]

--- a/databind.core/src/databind/core/converter.py
+++ b/databind.core/src/databind/core/converter.py
@@ -71,7 +71,11 @@ class Module(Converter):
             self.converters.append(converter)
 
     def get_converters(self, ctx: "Context") -> t.Iterator[Converter]:
-        yield from self.converters
+        for converter in self.converters:
+            if isinstance(converter, Module):
+                yield from converter.get_converters(ctx)
+            else:
+                yield converter
 
     def convert(self, ctx: "Context") -> t.Any:
         errors: t.List[t.Tuple[Converter, Exception]] = []

--- a/databind.core/src/databind/core/converter.py
+++ b/databind.core/src/databind/core/converter.py
@@ -154,18 +154,29 @@ class DelegateToClassmethodConverter(Converter):
     scenario (e.g. such as de/serializing JSON with the #databind.json.settings.JsonConverter setting).
     """
 
-    def __init__(self, *, serialize: "str | None" = None, deserialize: "str | None" = None) -> None:
+    def __init__(
+        self,
+        serialized_type: t.Union[t.Type[t.Any], t.Tuple[t.Type[t.Any], ...], None] = None,
+        *,
+        serialize: "str | None" = None,
+        deserialize: "str | None" = None,
+    ) -> None:
+        self._serialized_type = serialized_type
         self._serialize = serialize
         self._deserialize = deserialize
 
     def serialize(self, ctx: "Context") -> t.Any:
         if self._serialize is None or not isinstance(ctx.datatype, ClassTypeHint):
             raise NotImplementedError
+        if not isinstance(ctx.value, ctx.datatype.type):
+            raise ConversionError.expected(self, ctx, ctx.datatype.type)
         method: t.Callable[[t.Any], t.Any] = getattr(ctx.datatype.type, self._serialize)
         return method(ctx.value)
 
     def deserialize(self, ctx: "Context") -> t.Any:
         if self._deserialize is None or not isinstance(ctx.datatype, ClassTypeHint):
             raise NotImplementedError
+        if self._serialized_type is not None and not isinstance(ctx.value, self._serialized_type):
+            raise ConversionError.expected(self, ctx, self._serialized_type)
         method: t.Callable[[t.Any], t.Any] = getattr(ctx.datatype.type, self._deserialize)
         return method(ctx.value)

--- a/databind.core/src/databind/core/schema.py
+++ b/databind.core/src/databind/core/schema.py
@@ -246,7 +246,7 @@ def convert_dataclass_to_schema(dataclass_type: t.Union[type, GenericAlias, Clas
 
         # Continue with the base classes.
         for base in hint.bases or hint.type.__bases__:
-            base_hint = TypeHint(base).parameterize(parameter_map)
+            base_hint = TypeHint(base, source=hint.type).evaluate().parameterize(parameter_map)
             assert isinstance(base_hint, ClassTypeHint), f"nani? {base_hint}"
             if dataclasses.is_dataclass(base_hint.type):
                 queue.append(base_hint)

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -5,33 +5,37 @@ description = "Add a unit tests to demonstrate that deserializing a nested type 
 author = "@NiklasRosenstein"
 pr = "https://github.com/NiklasRosenstein/python-databind/pull/51"
 
-
 [[entries]]
 id = "89204ef2-6173-4d4e-b857-3af59db2de32"
 type = "fix"
 description = "Technically a breaking change, but any consumer who is relying on this behaviour probably does that implicitly and wants to change their code anyway. o_o -- The `CollectionConverter` no longer implicitly assumes `Any` as the item type if collection is not parameterized."
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"
 
 [[entries]]
 id = "0b05e104-7012-4a03-a995-12ed05878f0b"
 type = "improvement"
 description = "The `CollectionConverter` now properly infers the item type from the types base classes"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"
 
 [[entries]]
 id = "ae147797-2857-4e6e-b7af-d2c6c1152e59"
 type = "improvement"
 description = "The `MappingConverter` now does improved resolution of the key and value type just like the `CollectionConverter`; note that an unparameterized Mapping no longer has its key and value type fall back to `typing.Any`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"
 
 [[entries]]
 id = "08e63490-84b9-418d-8f26-39c770f17d59"
 type = "improvement"
 description = "Use `ConversionError.expected()` factory function in `PlainDatatypeConverter`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"
 
 [[entries]]
 id = "78c6beda-22dd-419e-848f-5835ab554efd"
 type = "tests"
 description = "Test `JsonConverter`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-databind/pull/52"

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "6ac5f7d0-aeb8-436c-bc2c-a178e2a82a74"
+type = "tests"
+description = "Add a unit tests to demonstrate that deserializing a nested type cannot work."
+author = "@NiklasRosenstein"

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -21,3 +21,9 @@ id = "ae147797-2857-4e6e-b7af-d2c6c1152e59"
 type = "improvement"
 description = "The `MappingConverter` now does improved resolution of the key and value type just like the `CollectionConverter`; note that an unparameterized Mapping no longer has its key and value type fall back to `typing.Any`"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "08e63490-84b9-418d-8f26-39c770f17d59"
+type = "improvement"
+description = "Use `ConversionError.expected()` factory function in `PlainDatatypeConverter`"
+author = "@NiklasRosenstein"

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -27,3 +27,9 @@ id = "08e63490-84b9-418d-8f26-39c770f17d59"
 type = "improvement"
 description = "Use `ConversionError.expected()` factory function in `PlainDatatypeConverter`"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "78c6beda-22dd-419e-848f-5835ab554efd"
+type = "tests"
+description = "Test `JsonConverter`"
+author = "@NiklasRosenstein"

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "0b05e104-7012-4a03-a995-12ed05878f0b"
 type = "improvement"
 description = "The `CollectionConverter` now properly infers the item type from the types base classes"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "ae147797-2857-4e6e-b7af-d2c6c1152e59"
+type = "improvement"
+description = "The `MappingConverter` now does improved resolution of the key and value type just like the `CollectionConverter`; note that an unparameterized Mapping no longer has its key and value type fall back to `typing.Any`"
+author = "@NiklasRosenstein"

--- a/databind.json/.changelog/_unreleased.toml
+++ b/databind.json/.changelog/_unreleased.toml
@@ -3,3 +3,15 @@ id = "6ac5f7d0-aeb8-436c-bc2c-a178e2a82a74"
 type = "tests"
 description = "Add a unit tests to demonstrate that deserializing a nested type cannot work."
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "89204ef2-6173-4d4e-b857-3af59db2de32"
+type = "fix"
+description = "Technically a breaking change, but any consumer who is relying on this behaviour probably does that implicitly and wants to change their code anyway. o_o -- The `CollectionConverter` no longer implicitly assumes `Any` as the item type if collection is not parameterized."
+author = "@NiklasRosenstein"
+
+[[entries]]
+id = "0b05e104-7012-4a03-a995-12ed05878f0b"
+type = "improvement"
+description = "The `CollectionConverter` now properly infers the item type from the types base classes"
+author = "@NiklasRosenstein"

--- a/databind.json/pyproject.toml
+++ b/databind.json/pyproject.toml
@@ -17,7 +17,7 @@ Repository = "https://github.com/NiklasRosenstein/python-databind"
 python = "^3.6.3"
 "databind.core" = "^4.3.2"
 nr-date = "^2.0.0"
-typeapi = "^1.4.2"
+typeapi = "^2.0.1"
 typing-extensions = ">=3.10.0"
 
 [tool.poetry.dev-dependencies]

--- a/databind.json/src/databind/json/converters.py
+++ b/databind.json/src/databind/json/converters.py
@@ -429,8 +429,7 @@ class PlainDatatypeConverter(Converter):
         adapter = adapters.get((source_type, target_type))
 
         if adapter is None:
-            msg = f"unable to {ctx.direction.name.lower()} {source_type.__name__} -> {target_type.__name__}"
-            raise ConversionError(self, ctx, msg)
+            raise ConversionError.expected(self, ctx, target_type, source_type)
 
         try:
             return adapter(ctx.value)

--- a/databind.json/src/databind/json/module.py
+++ b/databind.json/src/databind/json/module.py
@@ -55,6 +55,17 @@ class JsonModule(Module):
         self.register(StringifyConverter(duration, duration.parse, name="JsonModule:nr.date.duration"), first=True)
         self.register(LiteralConverter())
 
+        self.register(JsonConverterSupport(), first=True)
+
+
+class JsonConverterSupport(Module):
+    """
+    Handles the JsonConverter setting.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(__name__ + ".JsonConverterSupport")
+
     def get_converters(self, ctx: Context) -> Iterator[Converter]:
         converter_setting = ctx.get_setting(JsonConverter)
         if converter_setting is not None:

--- a/databind.json/src/databind/json/settings.py
+++ b/databind.json/src/databind/json/settings.py
@@ -56,5 +56,12 @@ class JsonConverter(ClassDecoratorSetting):
             self.supplier = supplier
 
     @staticmethod
-    def using_classmethods(*, serialize: "str | None" = None, deserialize: "str | None" = None) -> "JsonConverter":
-        return JsonConverter(DelegateToClassmethodConverter(serialize=serialize, deserialize=deserialize))
+    def using_classmethods(
+        serialized_type: t.Union[t.Type[t.Any], t.Tuple[t.Type[t.Any], ...], None] = None,
+        *,
+        serialize: "str | None" = None,
+        deserialize: "str | None" = None
+    ) -> "JsonConverter":
+        return JsonConverter(
+            DelegateToClassmethodConverter(serialized_type, serialize=serialize, deserialize=deserialize)
+        )

--- a/databind.json/src/databind/json/tests/converters_test.py
+++ b/databind.json/src/databind/json/tests/converters_test.py
@@ -200,7 +200,11 @@ def test_stringify_converter(direction: Direction) -> None:
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
 def test_mapping_converter(direction: Direction) -> None:
     mapper = make_mapper([AnyConverter(), MappingConverter(), PlainDatatypeConverter()])
-    assert mapper.convert(direction, {"a": 1}, t.Mapping) == {"a": 1}
+
+    with pytest.raises(ConversionError) as excinfo:
+        mapper.convert(direction, {"a": 1}, t.Mapping)
+    assert str(excinfo.value).splitlines()[0] == "could not find key/value type in TypeHint(typing.Mapping)"
+
     assert mapper.convert(direction, {"a": 1}, t.Mapping[str, int]) == {"a": 1}
     assert mapper.convert(direction, {"a": 1}, t.MutableMapping[str, int]) == {"a": 1}
     assert mapper.convert(direction, {"a": 1}, t.Dict[str, int]) == {"a": 1}

--- a/databind.json/src/databind/json/tests/converters_test.py
+++ b/databind.json/src/databind/json/tests/converters_test.py
@@ -302,7 +302,7 @@ def test_union_converter_flat_plain_types_not_supported(direction: Direction) ->
     if direction == Direction.DESERIALIZE:
         with pytest.raises(ConversionError) as excinfo:
             assert mapper.convert(direction, {"type": "int", "int": 42}, th)
-        assert "unable to deserialize dict -> int" in str(excinfo.value)
+        assert "expected int, got dict instead" in str(excinfo.value)
     else:
         with pytest.raises(ConversionError) as excinfo:
             assert mapper.convert(direction, 42, th)
@@ -524,7 +524,7 @@ def test_deserialize_tuple() -> None:
 
     with pytest.raises(ConversionError) as excinfo:
         databind.json.load([1, 42], t.Tuple[int, str])
-    assert excinfo.value.message == "unable to deserialize int -> str"
+    assert excinfo.value.message == "expected str, got int instead"
 
     with pytest.raises(ConversionError) as excinfo:
         databind.json.load([1, 42, 3], t.Tuple[int, int])

--- a/databind.json/src/databind/json/tests/converters_test.py
+++ b/databind.json/src/databind/json/tests/converters_test.py
@@ -537,10 +537,10 @@ def test__namedtuple__cannot_serde() -> None:
     nt = namedtuple("nt", ["a", "b"])
 
     with pytest.raises(ConversionError) as excinfo:
-        assert mapper.serialize(nt(1, 2), nt)
+        print(mapper.serialize(nt(1, 2), nt))
     assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(converters_test.nt)"
     with pytest.raises(ConversionError) as excinfo:
-        assert mapper.deserialize([1, 2], nt)
+        print(mapper.deserialize([1, 2], nt))
     assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(converters_test.nt)"
 
 

--- a/databind.json/src/databind/json/tests/converters_test.py
+++ b/databind.json/src/databind/json/tests/converters_test.py
@@ -229,7 +229,11 @@ def test_mapping_converter(direction: Direction) -> None:
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
 def test_collection_converter(direction: Direction) -> None:
     mapper = make_mapper([AnyConverter(), CollectionConverter(), PlainDatatypeConverter()])
-    assert mapper.convert(direction, [1, 2, 3], t.Collection) == [1, 2, 3]
+
+    with pytest.raises(ConversionError) as excinfo:
+        mapper.convert(direction, [1, 2, 3], t.Collection)
+    assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(typing.Collection)"
+
     assert mapper.convert(direction, [1, 2, 3], t.Collection[int]) == [1, 2, 3]
     assert mapper.convert(direction, [1, 2, 3], t.MutableSequence[int]) == [1, 2, 3]
     assert mapper.convert(direction, [1, 2, 3], t.List[int]) == [1, 2, 3]
@@ -523,15 +527,21 @@ def test_deserialize_tuple() -> None:
     assert excinfo.value.message == "expected a tuple of length 2, found 3"
 
 
-def test__namedtuple() -> None:
-    # NOTE: Need the AnyConverter because the namedtuple is not a dataclass and we don't have type information
-    #       for the fields.
+def test__namedtuple__cannot_serde() -> None:
+    """
+    There is no type information for #collections.namedtuples.
+    """
+
     mapper = make_mapper([CollectionConverter(), PlainDatatypeConverter(), AnyConverter()])
 
     nt = namedtuple("nt", ["a", "b"])
 
-    assert mapper.serialize(nt(1, 2), nt) == [1, 2]
-    assert mapper.deserialize([1, 2], nt) == nt(1, 2)
+    with pytest.raises(ConversionError) as excinfo:
+        assert mapper.serialize(nt(1, 2), nt)
+    assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(converters_test.nt)"
+    with pytest.raises(ConversionError) as excinfo:
+        assert mapper.deserialize([1, 2], nt)
+    assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(converters_test.nt)"
 
 
 def test__typing_NamedTuple() -> None:
@@ -614,3 +624,24 @@ def test__parameterized_self_seferential_generic_cannot_be_processed() -> None:
     assert mapper.deserialize(payload, Page[Page[Page[Page]]]) == Page(  # type: ignore[type-arg]
         "root", [Page("child", [Page("grandchild", [])])]
     )
+
+
+def test__list__fails_without_type_parameter() -> None:
+    mapper = make_mapper([AnyConverter(), CollectionConverter()])
+    with pytest.raises(ConversionError) as excinfo:
+        mapper.deserialize([1, 2, 3], list)
+    assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(list)"
+    with pytest.raises(ConversionError) as excinfo:
+        mapper.deserialize([1, 2, 3], t.List)
+    assert str(excinfo.value).splitlines()[0] == "could not find item type in TypeHint(typing.List)"
+
+
+def test__list__subclass_items_deserialized_correctly() -> None:
+    class MyList(t.List[SpecificPage]):
+        pass
+
+    mapper = make_mapper([SchemaConverter(), AnyConverter(), CollectionConverter(), PlainDatatypeConverter()])
+    assert mapper.deserialize([{"name": "foo", "children": []}], t.List[SpecificPage]) == MyList(
+        [SpecificPage("foo", [])]
+    )
+    assert mapper.deserialize([{"name": "foo", "children": []}], MyList) == MyList([SpecificPage("foo", [])])

--- a/docs/content/core/pitfalls.md
+++ b/docs/content/core/pitfalls.md
@@ -1,0 +1,47 @@
+# Pitfalls
+
+## Missing type parameters
+
+Databind will not simply assume `Any` for a type hint when it is not set. Instead, it will raise an error like to
+following when an unbound type parameter is encountered:
+
+    databind.core.converter.NoMatchingConverter: no deserializer for `TypeHint(~T_Page)` and payload of type `dict`
+
+> Note: The handling of missing type parameter depends on the serde implementation (e.g. `databind.json`), but it is a
+> convention that all implementations should follow by default.
+
+__Examples__
+
+(1)
+
+```py
+from databind.json import load
+
+load([1, "foo", {"name": "Doe"}], list)  # could not find item type in TypeHint(list)
+```
+
+(2)
+
+```py
+from dataclasses import dataclass
+from databind.json import load
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound="MyClass")
+
+@dataclass
+class MyClass(Generic[T]):
+    children: list[T]
+
+load({"children": [{"children": []}]}, MyClass)  # no deserializer for `TypeHint(~T)` and payload of type `dict`
+```
+
+The example (2) can only be fixed by creating a dedicated subclass:
+
+```py
+@dataclass
+class MySpecificClass(MyClass["MySpecificClass"]):
+    pass
+
+load({"children": [{"children": []}]}, MySpecificClass)
+```


### PR DESCRIPTION
Using `typeapi 2.0.1`, we can use it's new `ClassTypeHint.recurse_bases()` to ensure that forward refs are evaluated properly when searching through the bases of a class to find the item type for a collection or the key/value types for a mapping.
