### PR TITLE
Add None to the PlainDatatypeConverter

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "0240153b-1aaa-4801-b258-522c608bb936"
+type = "improvement"
+description = "Add None to the set of plain datatypes that can be de/serialized"
+author = "@rhaps0dy"

--- a/databind/src/databind/json/converters.py
+++ b/databind/src/databind/json/converters.py
@@ -2,7 +2,6 @@ import base64
 import datetime
 import decimal
 import enum
-from types import NoneType
 import typing as t
 
 from typeapi import (
@@ -395,7 +394,7 @@ class PlainDatatypeConverter(Converter):
         (int, float): float,
         (float, int): _int_lossless,
         (bool, bool): bool,
-        (NoneType, NoneType): lambda x: x,
+        (type(None), type(None)): lambda x: x,
     }
 
     # Used only during deserialization if the #fieldinfo.strict is disabled.
@@ -408,7 +407,7 @@ class PlainDatatypeConverter(Converter):
             (int, str): str,
             (float, str): str,
             (bool, str): str,
-            (NoneType, NoneType): lambda x: x,
+            (type(None), type(None)): lambda x: x,
         }
     )
 

--- a/databind/src/databind/json/converters.py
+++ b/databind/src/databind/json/converters.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import decimal
 import enum
+from types import NoneType
 import typing as t
 
 from typeapi import (
@@ -373,7 +374,7 @@ class OptionalConverter(Converter):
 
 
 class PlainDatatypeConverter(Converter):
-    """A converter for the plain datatypes #bool, #bytes, #int, #str and #float.
+    """A converter for the plain datatypes #bool, #bytes, #int, #str, #float and #null.
 
     Arguments:
       direction (Direction): The direction in which to convert (serialize or deserialize).
@@ -394,6 +395,7 @@ class PlainDatatypeConverter(Converter):
         (int, float): float,
         (float, int): _int_lossless,
         (bool, bool): bool,
+        (NoneType, NoneType): lambda x: x,
     }
 
     # Used only during deserialization if the #fieldinfo.strict is disabled.
@@ -406,6 +408,7 @@ class PlainDatatypeConverter(Converter):
             (int, str): str,
             (float, str): str,
             (bool, str): str,
+            (NoneType, NoneType): lambda x: x,
         }
     )
 
@@ -428,7 +431,6 @@ class PlainDatatypeConverter(Converter):
         )
         adapters = self._strict_adapters if strict.enabled else self._nonstrict_adapters
         adapter = adapters.get((source_type, target_type))
-
         if adapter is None:
             raise ConversionError.expected(self, ctx, target_type, source_type)
 

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -3,7 +3,6 @@ import datetime
 import decimal
 import enum
 import sys
-from types import NoneType
 import typing as t
 import uuid
 from collections import namedtuple
@@ -80,7 +79,7 @@ def test_plain_datatype_converter(direction: Direction) -> None:
             mapper.convert(direction, "foobar", int)
 
     # None should behave the same in both cases
-    assert mapper.convert(direction, None, NoneType) is None
+    assert mapper.convert(direction, None, type(None)) is None
     assert mapper.convert(direction, None, None) is None
 
 

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -3,6 +3,7 @@ import datetime
 import decimal
 import enum
 import sys
+from types import NoneType
 import typing as t
 import uuid
 from collections import namedtuple
@@ -77,6 +78,10 @@ def test_plain_datatype_converter(direction: Direction) -> None:
         assert mapper.convert(direction, "42", int) == 42
         with pytest.raises(ConversionError):
             mapper.convert(direction, "foobar", int)
+
+    # None should behave the same in both cases
+    assert mapper.convert(direction, None, NoneType) is None
+    assert mapper.convert(direction, None, None) is None
 
 
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))


### PR DESCRIPTION
Addresses #63. 

It's a bit silly to serialize/deserialize classes that contain no information, but it came up when iterating on configs for ML code. Feel free to reject.