### PR TITLE
Fix Union with Literals

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "ab7f2766-e6f5-4236-946d-bddedcd73433"
 type = "fix"
 description = "Fix ClassDecoratorSetting and get_class_settings to correctly handle __databind_settings__ on subclasses"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "6d0f41f2-f7f9-4808-af65-196a7a909b4f"
+type = "fix"
+description = "Fix #47: Union with Literal in them can now de/serialize"
+author = "@rhaps0dy"

--- a/databind/src/databind/core/union.py
+++ b/databind/src/databind/core/union.py
@@ -7,7 +7,7 @@ import sys
 import types
 import typing as t
 
-from typeapi import ClassTypeHint, TypeHint
+from typeapi import ClassTypeHint, LiteralTypeHint, TypeHint
 
 from databind.core.utils import T
 
@@ -46,6 +46,19 @@ class UnionMembers(abc.ABC):
         Raises:
           ValueError: If the *type_id* is not an ID among the union members.
         """
+
+    def get_type_id_for_value(self, value: t.Any) -> str:
+        """Given a Python value, return the ID of the type among the union members.
+
+        This method allows matching values against Literal type members, which cannot be
+        resolved by type alone. The default implementation falls back to `get_type_id(type(value))`.
+
+        Arguments:
+          value: The Python value to retrieve the type ID for.
+        Raises:
+          ValueError: If no member matches the *value*.
+        """
+        return self.get_type_id(type(value))
 
     @abc.abstractmethod
     def get_type_ids(self) -> t.List[str]:
@@ -100,6 +113,17 @@ class StaticUnionMembers(UnionMembers):
             if reference_type == type_ or isinstance(reference_type, ClassTypeHint) and reference_type.type == type_:
                 return type_id
         raise ValueError(f"type {type_} is not a member of {self}")
+
+    def get_type_id_for_value(self, value: t.Any) -> str:
+        # Check LiteralTypeHint members first (more specific — match value in reference_type.values).
+        # Members may be stored as raw typing annotations or as TypeHint instances, so wrap if needed.
+        for type_id in self.members:
+            reference_type = self.get_type_by_id(type_id)
+            hint = reference_type if isinstance(reference_type, TypeHint) else TypeHint(reference_type)
+            if isinstance(hint, LiteralTypeHint) and value in hint.values:
+                return type_id
+        # Then fall back to class/type members (existing type-based matching)
+        return self.get_type_id(type(value))
 
     def get_type_by_id(self, type_id: str) -> t.Any:
         try:
@@ -225,6 +249,15 @@ class ChainUnionMembers(UnionMembers):
             except ValueError as exc:
                 errors.append(exc)
         raise ValueError(f"{type_!r} is not a member of {self}\n" + "- \n".join(map(str, errors)))
+
+    def get_type_id_for_value(self, value: t.Any) -> str:
+        errors = []
+        for delegate in self.delegates:
+            try:
+                return delegate.get_type_id_for_value(value)
+            except ValueError as exc:
+                errors.append(exc)
+        raise ValueError(f"{value!r} is not a member of {self}\n" + "- \n".join(map(str, errors)))
 
     def get_type_by_id(self, type_id: str) -> t.Any:
         errors = []

--- a/databind/src/databind/json/converters.py
+++ b/databind/src/databind/json/converters.py
@@ -764,13 +764,19 @@ class UnionConverter(Converter):
     def convert(self, ctx: Context) -> t.Any:
         datatype = ctx.datatype
         union: t.Optional[Union]
+        literal_types: list[TypeHint] = []
+
         if isinstance(datatype, UnionTypeHint):
             if datatype.has_none_type():
                 raise NotImplementedError("unable to handle Union type with None in it")
-            if not all(isinstance(a, ClassTypeHint) for a in datatype):
-                raise NotImplementedError(f"members of plain Union must be concrete types: {datatype}")
-            members = {t.cast(ClassTypeHint, a).type.__name__: a for a in datatype}
-            if len(members) != len(datatype):
+
+            literal_types = [a for a in datatype if isinstance(a, LiteralTypeHint)]
+            non_literal_types = [a for a in datatype if not isinstance(a, LiteralTypeHint)]
+            if not all(isinstance(a, ClassTypeHint) for a in non_literal_types):
+                raise NotImplementedError(f"members of plain Union must be concrete or Literal types: {datatype}")
+
+            members = {t.cast(ClassTypeHint, a).type.__name__: a for a in non_literal_types}
+            if len(members) != len(non_literal_types):
                 raise NotImplementedError(f"members of plain Union cannot have overlapping type names: {datatype}")
             union = Union(members, Union.BEST_MATCH)
         elif isinstance(datatype, (AnnotatedTypeHint, ClassTypeHint)):
@@ -787,6 +793,11 @@ class UnionConverter(Converter):
                 member_type = union.members.get_type_by_id(member_name)
                 try:
                     return ctx.spawn(ctx.value, member_type, None).convert()
+                except ConversionError as exc:
+                    errors.append((exc.origin, exc))
+            for literal_type in literal_types:
+                try:
+                    return ctx.spawn(ctx.value, literal_type, None).convert()
                 except ConversionError as exc:
                     errors.append((exc.origin, exc))
             raise ConversionError(

--- a/databind/src/databind/json/converters.py
+++ b/databind/src/databind/json/converters.py
@@ -764,7 +764,6 @@ class UnionConverter(Converter):
     def convert(self, ctx: Context) -> t.Any:
         datatype = ctx.datatype
         union: t.Optional[Union]
-        literal_types: t.List[TypeHint] = []
 
         if isinstance(datatype, UnionTypeHint):
             if datatype.has_none_type():
@@ -775,9 +774,11 @@ class UnionConverter(Converter):
             if not all(isinstance(a, ClassTypeHint) for a in non_literal_types):
                 raise NotImplementedError(f"members of plain Union must be concrete or Literal types: {datatype}")
 
-            members = {t.cast(ClassTypeHint, a).type.__name__: a for a in non_literal_types}
+            members: t.Dict[str, t.Any] = {t.cast(ClassTypeHint, a).type.__name__: a for a in non_literal_types}
             if len(members) != len(non_literal_types):
                 raise NotImplementedError(f"members of plain Union cannot have overlapping type names: {datatype}")
+            for lit in literal_types:
+                members[type_repr(lit.hint)] = lit
             union = Union(members, Union.BEST_MATCH)
         elif isinstance(datatype, (AnnotatedTypeHint, ClassTypeHint)):
             union = ctx.get_setting(Union)
@@ -793,11 +794,6 @@ class UnionConverter(Converter):
                 member_type = union.members.get_type_by_id(member_name)
                 try:
                     return ctx.spawn(ctx.value, member_type, None).convert()
-                except ConversionError as exc:
-                    errors.append((exc.origin, exc))
-            for literal_type in literal_types:
-                try:
-                    return ctx.spawn(ctx.value, literal_type, None).convert()
                 except ConversionError as exc:
                     errors.append((exc.origin, exc))
             raise ConversionError(
@@ -818,8 +814,11 @@ class UnionConverter(Converter):
             member_type = union.members.get_type_by_id(member_name)
 
         else:
-            # Identify the member type based on the Python value type.
-            member_name = union.members.get_type_id(type(ctx.value))
+            # Identify the member type based on the Python value.
+            try:
+                member_name = union.members.get_type_id_for_value(ctx.value)
+            except ValueError as exc:
+                raise ConversionError(self, ctx, str(exc))
             member_type = union.members.get_type_by_id(member_name)
 
         nesting_key = union.nesting_key or member_name

--- a/databind/src/databind/json/converters.py
+++ b/databind/src/databind/json/converters.py
@@ -764,7 +764,7 @@ class UnionConverter(Converter):
     def convert(self, ctx: Context) -> t.Any:
         datatype = ctx.datatype
         union: t.Optional[Union]
-        literal_types: list[TypeHint] = []
+        literal_types: t.List[TypeHint] = []
 
         if isinstance(datatype, UnionTypeHint):
             if datatype.has_none_type():

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -834,3 +834,9 @@ def test_union_literal():
 
     assert mapper.serialize("bye", StrType) == "bye"
     assert mapper.serialize("other", StrType) == "other"
+
+    assert mapper.deserialize("hi", IntType) == "hi"
+    assert mapper.deserialize(2, IntType) == 2
+
+    assert mapper.deserialize("bye", StrType) == "bye"
+    assert mapper.deserialize("other", StrType) == "other"

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -821,3 +821,16 @@ def test_extra_keys_parent_decorated_child_inherits_and_can_override() -> None:
     with pytest.raises(ConversionError) as excinfo:
         mapper.deserialize({"a": 1, "b": "hello", "extra": "ignored"}, ChildOverriding)
     assert "extra" in str(excinfo.value)
+
+
+def test_union_literal():
+    mapper = make_mapper([UnionConverter(), PlainDatatypeConverter()])
+
+    IntType = int | t.Literal["hi", "bye"]
+    StrType = str | t.Literal["hi", "bye"]
+
+    assert mapper.serialize("hi", IntType) == "hi"
+    assert mapper.serialize(2, IntType) == 2
+
+    assert mapper.serialize("bye", StrType) == "bye"
+    assert mapper.serialize("other", StrType) == "other"

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -30,6 +30,7 @@ from databind.json.converters import (
     DatetimeConverter,
     DecimalConverter,
     EnumConverter,
+    LiteralConverter,
     MappingConverter,
     OptionalConverter,
     PlainDatatypeConverter,
@@ -333,6 +334,22 @@ def test_union_converter_best_match(direction: Direction) -> None:
 
 
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
+def test_union_converter_best_match_literal(direction: Direction) -> None:
+    mapper = make_mapper([UnionConverter(), PlainDatatypeConverter(), LiteralConverter()])
+
+    LiteralUnionType = t.Union[int, t.Literal["hi"], t.Literal["bye"]]
+
+    if direction == Direction.DESERIALIZE:
+        assert mapper.convert(direction, 42, LiteralUnionType) == 42
+        assert mapper.convert(direction, "hi", LiteralUnionType) == "hi"
+        assert mapper.convert(direction, "bye", LiteralUnionType) == "bye"
+    else:
+        assert mapper.convert(direction, 42, LiteralUnionType) == 42
+        assert mapper.convert(direction, "hi", LiteralUnionType) == "hi"
+        assert mapper.convert(direction, "bye", LiteralUnionType) == "bye"
+
+
+@pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
 def test_union_converter_keyed(direction: Direction) -> None:
     mapper = make_mapper([UnionConverter(), PlainDatatypeConverter()])
 
@@ -341,6 +358,31 @@ def test_union_converter_keyed(direction: Direction) -> None:
         assert mapper.convert(direction, {"int": 42}, th) == 42
     else:
         assert mapper.convert(direction, 42, th) == {"int": 42}
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
+def test_union_converter_keyed_literal(direction: Direction) -> None:
+    mapper = make_mapper([UnionConverter(), PlainDatatypeConverter(), LiteralConverter()])
+
+    th = te.Annotated[
+        t.Union[int, t.Literal["hi"], t.Literal["bye"]],
+        Union({"int": int, "HiType": t.Literal["hi"], "ByeType": t.Literal["bye"]}, style=Union.KEYED),
+    ]
+    if direction == Direction.DESERIALIZE:
+        assert mapper.convert(direction, {"int": 42}, th) == 42
+        assert mapper.convert(direction, {"HiType": "hi"}, th) == "hi"
+        assert mapper.convert(direction, {"ByeType": "bye"}, th) == "bye"
+
+        with pytest.raises(ConversionError):
+            mapper.convert(direction, {"ByeType": "hi"}, th)
+    else:
+        assert mapper.convert(direction, 42, th) == {"int": 42}
+        assert mapper.convert(direction, "hi", th) == {"HiType": "hi"}
+        assert mapper.convert(direction, "bye", th) == {"ByeType": "bye"}
+
+        with pytest.raises(ConversionError):
+            mapper.convert(direction, {"ByeType": "hi"}, th)
 
 
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
@@ -717,6 +759,7 @@ def test__JsonConverter__using_classmethods_on_plain_class() -> None:
     mapper = make_mapper([JsonConverterSupport()])
     assert mapper.serialize(MyCls(), MyCls) == "MyCls"
     assert mapper.deserialize("MyCls", MyCls) == MyCls()
+
 
 
 UnboundTypeVar = t.TypeVar("UnboundTypeVar")

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -755,7 +755,6 @@ def test__JsonConverter__using_classmethods_on_plain_class() -> None:
     assert mapper.deserialize("MyCls", MyCls) == MyCls()
 
 
-
 UnboundTypeVar = t.TypeVar("UnboundTypeVar")
 
 

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -860,11 +860,11 @@ def test_extra_keys_parent_decorated_child_inherits_and_can_override() -> None:
     assert "extra" in str(excinfo.value)
 
 
-def test_union_literal():
+def test_union_literal() -> None:
     mapper = make_mapper([UnionConverter(), PlainDatatypeConverter(), LiteralConverter()])
 
-    IntType = int | t.Literal["hi", "bye"]
-    StrType = str | t.Literal["hi", "bye"]
+    IntType = t.Union[int, t.Literal["hi", "bye"]]
+    StrType = t.Union[str, t.Literal["hi", "bye"]]
 
     assert mapper.serialize("hi", IntType) == "hi"
     assert mapper.serialize(2, IntType) == 2

--- a/databind/src/databind/json/tests/converters_test.py
+++ b/databind/src/databind/json/tests/converters_test.py
@@ -339,14 +339,9 @@ def test_union_converter_best_match_literal(direction: Direction) -> None:
 
     LiteralUnionType = t.Union[int, t.Literal["hi"], t.Literal["bye"]]
 
-    if direction == Direction.DESERIALIZE:
-        assert mapper.convert(direction, 42, LiteralUnionType) == 42
-        assert mapper.convert(direction, "hi", LiteralUnionType) == "hi"
-        assert mapper.convert(direction, "bye", LiteralUnionType) == "bye"
-    else:
-        assert mapper.convert(direction, 42, LiteralUnionType) == 42
-        assert mapper.convert(direction, "hi", LiteralUnionType) == "hi"
-        assert mapper.convert(direction, "bye", LiteralUnionType) == "bye"
+    assert mapper.convert(direction, 42, LiteralUnionType) == 42
+    assert mapper.convert(direction, "hi", LiteralUnionType) == "hi"
+    assert mapper.convert(direction, "bye", LiteralUnionType) == "bye"
 
 
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
@@ -360,7 +355,6 @@ def test_union_converter_keyed(direction: Direction) -> None:
         assert mapper.convert(direction, 42, th) == {"int": 42}
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("direction", (Direction.SERIALIZE, Direction.DESERIALIZE))
 def test_union_converter_keyed_literal(direction: Direction) -> None:
     mapper = make_mapper([UnionConverter(), PlainDatatypeConverter(), LiteralConverter()])
@@ -867,7 +861,7 @@ def test_extra_keys_parent_decorated_child_inherits_and_can_override() -> None:
 
 
 def test_union_literal():
-    mapper = make_mapper([UnionConverter(), PlainDatatypeConverter()])
+    mapper = make_mapper([UnionConverter(), PlainDatatypeConverter(), LiteralConverter()])
 
     IntType = int | t.Literal["hi", "bye"]
     StrType = str | t.Literal["hi", "bye"]


### PR DESCRIPTION
NOTE: currently this PR has a test that fails: serializing a Keyed union with literals. Fixing this requires changing the signature of `get_type_id` for UnionMembers for a bunch of classes, which I don't feel like doing now. Do I need to do it?

Partially Fixes #47 

Unions with Literal types on them could not be serialized or deserialized. They now can.