### PR TITLE
Add monthly downloads badge to README

### DIFF
--- a/databind/README.md
+++ b/databind/README.md
@@ -6,6 +6,7 @@
   <img src="https://img.shields.io/pypi/pyversions/databind?style=flat" alt="Python versions">
   <a href="https://pypi.org/project/databind/"><img src="https://img.shields.io/pypi/v/databind?flat"></a>
   <a href="https://NiklasRosenstein.github.io/python-databind/"><img src="https://img.shields.io/badge/Documentation-blue?style=flat&logo=gitbook&logoColor=white" alt="Documentation"></a>
+  <a href = "https://piptrends.com/package/databind" alt = "databind Downloads Last Month"><img alt="databind Downloads Last Month by pip Trends" src="https://assets.piptrends.com/get-last-month-downloads-badge/databind.svg"></a>
 </p>
 
 The `databind` package provides a (de)serialization framework that understands most native Python types as well as


### PR DESCRIPTION
This PR is to add a monthly downloads count badge to the README. I have been working on building a badge system for python packages to display some stats like monthly downloads etc. You can view them here at - https://piptrends.com/package/databind

We are trying to build a learning forum at pip Trends, where developers can find everything they need to get started with python and python packages.

The badge links to databind's pip Trends page, where we display some stats and documentation. Soon we plan on adding simple getting started articles etc. as well to this page.(These are open to contributions)
If required, this link can be removed. This PR is only to share the badge we have built.