### PR TITLE
Add Python 3.13–3.15 to CI matrix

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "6d0f41f2-f7f9-4808-af65-196a7a909b4f"
 type = "fix"
 description = "Fix #47: Union with Literal in them can now de/serialize"
 author = "@rhaps0dy"
+
+[[entries]]
+id = "9cb46299-4432-402c-8c31-327ef4daadd4"
+type = "improvement"
+description = "Add Python 3.13, 3.14, and 3.15 (pre-release) to CI test matrix"
+author = "@NiklasRosenstein"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,12 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     steps:
     - uses: actions/checkout@v4
     - uses: NiklasRosenstein/slap@gha/install/v1
     - uses: actions/setup-python@v5
-      with: { python-version: "${{ matrix.python-version }}" }
+      with:
+        python-version: "${{ matrix.python-version }}"
+        allow-prereleases: true
     - run: slap install --link --no-venv-check
     - run: slap test
     - run: slap publish --dry


### PR DESCRIPTION
## Summary
- Add explicit Python 3.13 and 3.14 entries to the CI test matrix (replacing the `3.x` wildcard)
- Add Python 3.15 (pre-release) with `allow-prereleases: true` and `continue-on-error` so failures are informational
- No code changes needed — the codebase is already forward-compatible

## Test plan
- [x] CI runs pass for Python 3.8–3.14
- [x] Python 3.15 job runs (may fail due to pre-release status, should not block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)